### PR TITLE
Reduced api calls

### DIFF
--- a/routes/web.php
+++ b/routes/web.php
@@ -4,24 +4,9 @@ use Illuminate\Http\Request;
 use Illuminate\Support\Facades\Cache;
 use Illuminate\Support\Facades\Http;
 use Illuminate\Support\Facades\Route;
+use Rapidez\Pro6ppPostcode\Http\Controllers\Pro6ppController;
 
 Route::middleware('web')->group(function () {
     // We place this in this middleware for the CSRF protection.
-    Route::match(['get', 'post'], '/api/pro6pp', function (Request $request) {
-        $request->merge([
-            'postcode' => strtoupper(str_replace(' ', '', $request->postcode)),
-        ])->validate([
-            'postcode' => 'required|string|max:6',
-            'housenumber' => 'required',
-        ]);
-
-        $cacheKey = 'pro6pp-'.$request->postcode.'-'.$request->housenumber;
-
-        return Cache::rememberForever($cacheKey, function () use ($request) {
-            return Http::pro6pp()->get('/autocomplete', [
-                'nl_sixpp'=> $request->postcode,
-                'streetnumber'=> $request->housenumber,
-            ])->throw()->json();
-        });
-    });
+    Route::match(['get', 'post'], '/api/pro6pp', Pro6ppController::class);
 });

--- a/src/Http/Controllers/Pro6ppController.php
+++ b/src/Http/Controllers/Pro6ppController.php
@@ -1,0 +1,53 @@
+<?php
+
+namespace Rapidez\Pro6ppPostcode\Http\Controllers;
+
+use Illuminate\Http\Request;
+use Illuminate\Support\Facades\Cache;
+use Illuminate\Support\Facades\Http;
+
+class Pro6ppController
+{
+    public function __invoke(Request $request)
+    {
+        $request->merge([
+            'postcode' => strtoupper(str_replace(' ', '', $request->postcode)),
+        ])->validate([
+            'postcode' => 'required|string|max:6',
+            'housenumber' => 'required',
+        ]);
+
+        $cacheKey = 'pro6pp-'.$request->postcode;
+
+        $response = Cache::rememberForever($cacheKey, function () use ($request) {
+            return Http::pro6pp()->get('/autocomplete', [
+                'nl_sixpp'=> $request->postcode
+            ])->throw()->json();
+        });
+
+        $response['results'] = collect($response['results'])->filter(function ($result) use ($request) {
+            return $this->isHouseNumberValid($request->housenumber, $result['streetnumbers']);
+        })->values()->all();
+
+        return $response;
+    }
+
+    protected function isHouseNumberValid(string $housenumber, string $validRanges /** = '1;11-13;21-27;33;37-49;1 A;1 B;1 C;1 D;1 E' */)
+    {
+        $houseNumberWithoutAddition = (int) preg_replace('/\D/', '', $housenumber);
+
+        return collect(explode(';', $validRanges))->contains(function ($range) use ($housenumber, $houseNumberWithoutAddition) {
+            $range = trim($range);
+            if ($range === $housenumber || (int)preg_replace('/\D/', '', $range) === $houseNumberWithoutAddition) {
+                return true;
+            }
+
+            if (strpos($range, '-') !== false) {
+                list($start, $end) = array_map('trim', explode('-', $range));
+                return is_numeric($start) && is_numeric($end) && $houseNumberWithoutAddition >= $start && $houseNumberWithoutAddition <= $end;
+            }
+
+            return false;
+        });
+    }
+}

--- a/src/Http/Controllers/Pro6ppController.php
+++ b/src/Http/Controllers/Pro6ppController.php
@@ -17,11 +17,11 @@ class Pro6ppController
             'housenumber' => 'required',
         ]);
 
-        $cacheKey = 'pro6pp-'.$request->postcode;
+        $cacheKey = 'pro6pp-' . $request->postcode;
 
         $response = Cache::rememberForever($cacheKey, function () use ($request) {
             return Http::pro6pp()->get('/autocomplete', [
-                'nl_sixpp'=> $request->postcode
+                'nl_sixpp' => $request->postcode
             ])->throw()->json();
         });
 
@@ -38,7 +38,7 @@ class Pro6ppController
 
         return collect(explode(';', $validRanges))->contains(function ($range) use ($housenumber, $houseNumberWithoutAddition) {
             $range = trim($range);
-            if ($range === $housenumber || (int)preg_replace('/\D/', '', $range) === $houseNumberWithoutAddition) {
+            if ($range === $housenumber || (int) preg_replace('/\D/', '', $range) === $houseNumberWithoutAddition) {
                 return true;
             }
 


### PR DESCRIPTION
Pro6pp potentially returns multiple results if you only pass the postcode.
This means we could match the housenumber ourselves, allowing us to cache per postcode range instead of postcode + housenumber