### PR TITLE
Dispatch change event on parent if address updated

### DIFF
--- a/resources/js/package.js
+++ b/resources/js/package.js
@@ -13,7 +13,7 @@ const getAddressFromPro6pp = useMemoize(async function (postcode, housenumber) {
     )
 })
 
-async function updateAddressFromPro6pp(address) {
+async function updateAddressFromPro6pp(address, event) {
     if ((address?.country_id || address?.country_code) != 'NL') {
         return
     }
@@ -42,6 +42,7 @@ async function updateAddressFromPro6pp(address) {
 
     address.city = foundAddress.city
     address.street[0] = foundAddress.street
+    event?.target?.parentElement?.dispatchEvent?.(new Event('change', {bubbles: true}));
 }
 
 on('postcode-change', useDebounceFn(updateAddressFromPro6pp, 100), { autoremove: false })


### PR DESCRIPTION
Based on the changes in rapidez/core#1244
This change will not cause breakages if the event is not passed.

It will trigger a bubbling change event, meaning it will trigger a graphql mutation in the checkout
https://github.com/rapidez/core/blob/6fd078f0763ba9800e2a97edc1716f0f7753b0d8/resources/views/checkout/steps/shipping-address.blade.php#L19